### PR TITLE
Fixing regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "karma-tap": "^3.1.1",
     "karma-tape-reporter": "^1.0.3",
     "substance": "substance/substance#kaikoura",
-    "substance-bundler": "^0.15.1",
-    "substance-test": "^0.8.0"
+    "substance-bundler": "^0.15.3",
+    "substance-test": "^0.9.1"
   },
   "files": [
     "dist",

--- a/test/engine/TestCell.js
+++ b/test/engine/TestCell.js
@@ -23,7 +23,7 @@ export default class TestCell extends EventEmitter {
       this.expr = parse(exprStr)
       this.expr.id = this.id
       this.expr.cell = this
-      this.expr.on('value:updated', this.setValue, this)
+      this.expr.on('evaluation:finished', this.onEvaluationFinished, this)
     } catch (err) {
       this.expr = null
       this.error = err
@@ -35,6 +35,10 @@ export default class TestCell extends EventEmitter {
     if (TestCell.DEBUG) console.info('Updating value.', this.id, val)
     this.value = val
     this.emit('value:updated')
+  }
+
+  onEvaluationFinished() {
+    this.setValue(this.expr.getValue())
   }
 
 }


### PR DESCRIPTION
The lately introduced test runner did not propagate the exit code correctly, which prevented to reveal a regression introduced by e2b945d57f2751cd5665cb30b0dac031ea341910